### PR TITLE
fix: prevent u32 integer underflow in feature subtraction

### DIFF
--- a/pybiber/parse_functions.py
+++ b/pybiber/parse_functions.py
@@ -217,12 +217,15 @@ def _block_lexical_membership(
             pl.col("gerunds_n").fill_null(strategy="zero"),
             pl.col("f_51_demonstratives").fill_null(strategy="zero"),
         ])
+        # Cast to Int64 before subtraction to prevent u32 underflow
+        # (same pattern as f_23_wh_clause fix for issue #5).
         .with_columns(
-            (
-                pl.col("f_16_other_nouns")
-                - pl.col("gerunds_n")
-                - pl.col("f_14_nominalizations")
-            ).alias("f_16_other_nouns")
+            pl.max_horizontal(
+                pl.col("f_16_other_nouns").cast(pl.Int64)
+                - pl.col("gerunds_n").cast(pl.Int64)
+                - pl.col("f_14_nominalizations").cast(pl.Int64),
+                pl.lit(0),
+            ).cast(pl.UInt32).alias("f_16_other_nouns")
         )
         .sort("doc_id", descending=False)
     )
@@ -544,21 +547,18 @@ def _block_clause_embedding(
             pl.col("f_38_other_adv_sub").fill_null(strategy="zero"),
             pl.col("f_60_that_deletion").fill_null(strategy="zero"),
         ])
-        # Guard: avoid double-counting WH clauses and WH relatives
+        # Guard: avoid double-counting WH clauses and WH relatives.
+        # Cast to Int64 before subtraction to prevent u32 underflow when
+        # f_31 + f_32 > f_23 (the guard "> 0" alone is ineffective for
+        # unsigned types because the wrapped value is still positive).
         .with_columns(
-            (
-                pl.col("f_23_wh_clause")
-                - pl.col("f_31_wh_subj")
-                - pl.col("f_32_wh_obj")
-            ).alias("_f23_adj")
+            pl.max_horizontal(
+                pl.col("f_23_wh_clause").cast(pl.Int64)
+                - pl.col("f_31_wh_subj").cast(pl.Int64)
+                - pl.col("f_32_wh_obj").cast(pl.Int64),
+                pl.lit(0),
+            ).cast(pl.UInt32).alias("f_23_wh_clause")
         )
-        .with_columns(
-            pl.when(pl.col("_f23_adj") > 0)
-            .then(pl.col("_f23_adj"))
-            .otherwise(0)
-            .alias("f_23_wh_clause")
-        )
-        .drop("_f23_adj")
         .sort("doc_id", descending=False)
     )
 


### PR DESCRIPTION
Polars count columns are u32, so subtracting them can wrap around instead of going negative. The existing guard `> 0` doesn't help because the wrapped value (~4294967293) is still positive.

I cast to Int64 before the subtraction and clamp to zero with `pl.max_horizontal(..., pl.lit(0))`, then cast back to UInt32 to preserve the downstream type contract. Applied the same fix to `f_16_other_nouns` in `_block_lexical_membership` which has the same root cause but had no guard at all.

Quick Polars demo of the before/after:

```
a=2, b=2, c=1  →  old: 4294967295  new: 0
a=0, b=2, c=1  →  old: 4294967293  new: 0
a=5, b=2, c=1  →  old: 2           new: 2  (unchanged)
```

Closes #5

Made with [Cursor](https://cursor.com)